### PR TITLE
refactor(chezmoi): Complete refactor for declarative management

### DIFF
--- a/.chezmoiscripts/run_onchange_fetch.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_fetch.sh.tmpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 
 # Note: This script is a utility with functions to fetch system info.
 # When run by 'chezmoi apply', it will only print its help message by default.

--- a/.chezmoiscripts/run_onchange_install_base_tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_install_base_tools.sh.tmpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 
 # This script installs a set of base development tools.
 # It is designed for Termux, but is safe to run on other systems.

--- a/.chezmoiscripts/run_onchange_install_cli_tools.sh
+++ b/.chezmoiscripts/run_onchange_install_cli_tools.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 
 # This script installs additional CLI tools using go and npm.
 

--- a/.chezmoiscripts/run_onchange_install_colortoys.sh
+++ b/.chezmoiscripts/run_onchange_install_colortoys.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 
 # This script installs a collection of "color toy" scripts for fun.
 

--- a/.chezmoiscripts/run_onchange_install_nodejs.sh
+++ b/.chezmoiscripts/run_onchange_install_nodejs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 
 # This script installs Node.js (LTS).
 # It is designed for Termux, but is safe to run on other systems.

--- a/.chezmoiscripts/run_onchange_install_python.sh
+++ b/.chezmoiscripts/run_onchange_install_python.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 
 # This script installs Python and related tools.
 # It is designed for Termux, but is safe to run on other systems.

--- a/.chezmoiscripts/run_onchange_install_visuals.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_install_visuals.sh.tmpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 
 # This script will install visual enhancements.
 # It contains logic for Termux and gracefully skips it on other systems.

--- a/.chezmoiscripts/run_onchange_install_youtube_dl.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_install_youtube_dl.sh.tmpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 
 # This script installs the YouTube-DL feature for Termux.
 # It is safe to run on other systems, where it will do nothing.

--- a/dot_config/yt-dlp/config
+++ b/dot_config/yt-dlp/config
@@ -1,0 +1,13 @@
+--no-mtime
+--embed-metadata
+--embed-thumbnail
+--embed-chapters
+--embed-subs
+# --sub-format srt
+# --convert-subs srt
+-P "$HOME/storage/shared/Youtube-DL/"
+-o "%(title).40s.%(ext)s"
+--windows-filenames
+--write-subs
+--playlist-reverse
+--no-abort-on-error

--- a/dot_config/yt-dlp/sponsorblock.conf
+++ b/dot_config/yt-dlp/sponsorblock.conf
@@ -1,0 +1,2 @@
+--sponsorblock-remove all
+--config-locations "$HOME/.config/yt-dlp/config"

--- a/dot_local/bin/executable_rxfetch
+++ b/dot_local/bin/executable_rxfetch
@@ -1,9 +1,4 @@
-#!/usr/bin/env bash
-
-# Note: This is a user-facing utility script to fetch system info.
-# It is not being installed to the system path automatically anymore.
-# To use it, you should move it to a 'bin' directory in your chezmoi
-# source and let 'chezmoi apply' symlink it for you.
+#!/data/data/com.termux/files/usr/bin/bash
 
 magenta="\033[1;35m"; green="\033[1;32m"; white="\033[1;37m"; blue="\033[1;34m"; red="\033[1;31m"; black="\033[1;40;30m"; yellow="\033[1;33m"; cyan="\033[1;36m"; reset="\033[0m"
 c0=${reset}; c1=${magenta}; c2=${green}; c3=${white}; c4=${blue}; c5=${red}; c6=${yellow}; c7=${cyan}

--- a/dot_termux/bin/executable_termux-url-opener
+++ b/dot_termux/bin/executable_termux-url-opener
@@ -1,0 +1,125 @@
+#!/data/data/com.termux/files/usr/bin/bash
+clear
+
+DOWNLOAD_PATH="$HOME/storage/shared/Youtube-DL/"
+PLAYLIST="%(extractor)s/playlists/%(playlist_title)s_%(playlist_id)s/%(n_entries-playlist_index)03d - %(uploader)s - %(title)s [%(id)s].%(ext)s"
+CHANNEL="%(extractor)s/channel/%(uploader)s_%(channel_id)s/%(title)s [%(id)s].%(ext)s"
+CONFIG_PATH="$HOME/.config/yt-dlp/"
+NC='\033[0m'
+
+function echo_bold() { echo -ne "\033[0;1;34m${*}${NC}\n"; }
+function echo_success() { echo -ne "\033[1;32m${*}${NC}\n"; }
+function echo_warning() { echo -ne "\033[1;33m${*}${NC}\n"; }
+function echo_danger() { echo -ne "\033[1;31m${*}${NC}\n"; }
+function echo_error() { echo -ne "\033[0;1;31merror:\033[0;31m\t${*}${NC}\n"; }
+
+function isSponsorblockAlive() {
+    #* HTTP/2 400 = bad request = api is working 1
+    #* HTTP/2 200 = ok = api is working 1
+    #! HTTP/2 404 = not found = api is not working 0
+    #! HTTP/2 500 = internal server error = api is not working 0
+    res=$(curl -Is https://sponsor.ajay.app/api/skipSegments | grep "HTTP" | awk '{print $2}')
+    if [ "$res" == "200" ] || [ "$res" == "400" ]; then
+        echo_success "sponsorblock api is working"
+        return 1
+    else
+        echo_warning "sponsorblock api is not working"
+        return 0
+    fi
+}
+
+function downloadVideo() {
+    echo -e "\\nDownloading video...\\n"
+    yt-dlp --config-locations "${CONFIG_PATH}config" -F "$1"
+    echo_warning "Choose your video quality (<enter> for: 'best'):"
+    read -p "" video
+    echo_warning "Choose your audio quality (<enter> for: 'best'):"
+    read -p "" audio
+    echo_warning "Input video name:"
+    read -p "" name
+
+    if [[ "$video" = "" ]]; then
+        video="best"
+    fi
+    if [[ "$audio" = "" ]]; then
+        audio="best"
+    fi
+    if [[ "$name" = "" ]]; then
+        name="%(title).40s [%(id)s].%(ext)s"
+    fi
+    if isSponsorblockAlive; then
+        # sucess
+        yt-dlp --config-locations "${CONFIG_PATH}sponsorblock.conf" -P "$DOWNLOAD_PATH" -o "$name" -f "$video"+"$audio" "$1"
+    else
+        # fail
+        yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -o "$name" -f "$video"+"$audio" "$1"
+    fi
+}
+
+function downloadChannel() {
+    echo "Downloading channel..."
+    if isSponsorblockAlive; then
+        yt-dlp --config-locations "${CONFIG_PATH}sponsorblock.conf" -P "$DOWNLOAD_PATH" -o "$CHANNEL" "$1"
+    else
+        yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -o "$CHANNEL" "$1"
+    fi
+}
+
+function downloadPlaylist() {
+    echo "Downloading playlist..."
+    if isSponsorblockAlive; then
+        yt-dlp --config-locations "${CONFIG_PATH}sponsorblock.conf" -P "$DOWNLOAD_PATH" -o "$PLAYLIST" "$1"
+    else
+        yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -o "$PLAYLIST" "$1"
+    fi
+}
+
+function downloadAudio() {
+    echo "Downloading audio..."
+    if isSponsorblockAlive; then
+        yt-dlp --config-locations "${CONFIG_PATH}sponsorblock.conf" -P "$DOWNLOAD_PATH" -x "$1"
+    else
+        yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -x "$1"
+    fi
+}
+
+# If shared element is a youtube link
+if [[ "$1" =~ ^.*youtu.*$ ]] || [[ "$1" =~ ^.*youtube.*$ ]]; then
+    echo_bold "Downloading...\\n>URL: ${1}"
+    echo_warning "Choose between the following options:"
+    echo_bold "1. Video mode (choose quality and name)"
+    echo_bold "2. Playlist mode"
+    echo_bold "3. Channel mode"
+    echo_bold "4. Audio only mode"
+
+    echo_warning "Enter your choice:"
+    read -p "" choice
+
+    case $choice in
+    1)
+        downloadVideo "$1"
+        ;;
+    2)
+        downloadPlaylist "$1"
+        ;;
+    3)
+        downloadChannel "$1"
+        ;;
+    4)
+        downloadAudio "$1"
+        ;;
+    *)
+        echo_error "\\nInvalid choice!\\n"
+        ;;
+    esac
+
+# Weird case i don't know when it happens
+elif [[ "$1" =~ ^.*nourlselected.*$ ]]; then
+    echo "There was an error"
+
+# If shared element is NOT a youtube link
+else
+    yt-dlp --config-locations "${CONFIG_PATH}config" -P "$DOWNLOAD_PATH" -f 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best' "$1"
+fi
+
+read -p "Press enter to continue"


### PR DESCRIPTION
This commit finalizes the refactoring of the `chezmoi` configuration by moving previously script-copied files into the `chezmoi` source tree. This ensures they are managed declaratively, which is the correct `chezmoi` pattern.

- Moves `rxfetch` to `dot_local/bin/` to be managed as an executable.
- Moves `yt-dlp` configs to `dot_config/yt-dlp/`.
- Moves `termux-url-opener` to `dot_termux/bin/`.

This completes the work of making the dotfiles portable, robust, and compatible with `chezmoi`'s philosophy.